### PR TITLE
Generate notebooks from CI

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,8 @@ const converter_path = joinpath(@__DIR__, "../converter")
 # notebook deployment phase
 using Pkg
 Pkg.activate(converter_path)
+Pkg.instantiate()
+
 include(joinpath(converter_path, "convert_pages.jl"))
 
 Documenter.deploydocs(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,3 +13,16 @@ makedocs(
 )
 
 Documenter.deploydocs(repo = "github.com/jump-dev/JuMPTutorials.jl.git")
+
+const converter_path = joinpath(@__DIR__, "../converter")
+
+# notebook deployment phase
+using Pkg
+Pkg.activate(converter_path)
+include(joinpath(converter_path, "convert_pages.jl"))
+
+Documenter.deploydocs(
+    repo = "github.com/jump-dev/JuMPTutorials.jl.git",
+    target = "../notebook",
+    branch = "notebook",
+)


### PR DESCRIPTION
Instead of manually generating the notebooks, allow building them from travis.
The next step will be removing the notebooks from the source